### PR TITLE
add reader_endpoint_address output to this module

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -22,3 +22,8 @@ output "host" {
   value       = module.dns.hostname
   description = "Redis hostname"
 }
+
+output "reader_endpoint_address" {
+  value       = join("", compact(aws_elasticache_replication_group.default[*].reader_endpoint_address))
+  description = "The address of the endpoint for the reader node in the replication group, if the cluster mode is disabled."
+}


### PR DESCRIPTION
## what
Copied from 
github.com/cloudposse/terraform-aws-elasticache-redis/blob/main/outputs.tf

Add reader_endpoint_address output to use in Terraform modules


