### PR TITLE
Add support for the engine variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -174,6 +174,7 @@ resource "aws_elasticache_replication_group" "default" {
   maintenance_window         = var.maintenance_window
   notification_topic_arn     = var.notification_topic_arn
   engine_version             = var.engine_version
+  engine                     = var.engine
   at_rest_encryption_enabled = var.at_rest_encryption_enabled
   transit_encryption_enabled = var.transit_encryption_enabled
   kms_key_id                 = var.at_rest_encryption_enabled ? var.kms_key_id : null

--- a/variables.tf
+++ b/variables.tf
@@ -57,7 +57,13 @@ variable "parameter" {
 variable "engine_version" {
   type        = string
   default     = "4.0.10"
-  description = "Redis engine version"
+  description = "Redis/Valkey engine version"
+}
+
+variable "engine" {
+  type        = string
+  default     = "redis"
+  description = "Redis or Valkey as a version"
 }
 
 variable "at_rest_encryption_enabled" {


### PR DESCRIPTION
## what

Add support for the engine variable in the module

## why

To support valkey it's necessary to be able to set the engine away from the `redis` default
## references

This is how cloudposse added support for valkey https://github.com/cloudposse/terraform-aws-elasticache-redis/pull/249
