### PR TITLE
Set `auth_token_update_strategy` to `ROTATE` by default to handle new provider logic

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -186,6 +186,7 @@ resource "aws_elasticache_replication_group" "default" {
   apply_immediately          = var.apply_immediately
   data_tiering_enabled       = var.data_tiering_enabled
   auto_minor_version_upgrade = var.auto_minor_version_upgrade
+  auth_token_update_strategy = var.auth_token_update_strategy
 
   dynamic "log_delivery_configuration" {
     for_each = var.log_delivery_configuration

--- a/variables.tf
+++ b/variables.tf
@@ -278,3 +278,14 @@ variable "insufficient_data_actions" {
   type        = list(string)
   default     = []
 }
+
+variable "auth_token_update_strategy" {
+  description = "Strategy to use when updating the auth_token. Valid values: SET, ROTATE, DELETE."
+  type        = string
+  default     = "ROTATE"
+
+  validation {
+    condition     = contains(["SET", "ROTATE", "DELETE"], var.auth_token_update_strategy)
+    error_message = "auth_token_update_strategy must be one of SET, ROTATE, or DELETE if auth_token is set."
+  }
+}


### PR DESCRIPTION
Update the default value for `auth_token_update_strategy` to handle behavior changes in the v6 provider.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-6-upgrade#resource-aws_elasticache_replication_group

[Tested on vhistory-prod1](https://app.terraform.io/app/verkada/services-vhistory-prod1/runs/run-iURAASDQnzkPLtax)